### PR TITLE
chore: fix clsx dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
         "@remix-run/express": "^2.8.0",
         "@remix-run/node": "^2.8.0",
         "@remix-run/react": "^2.8.0",
-        "clx": "^1.0.0",
+        "clsx": "^2.1.0",
         "compression": "^1.7.4",
         "express": "^4.18.2",
         "invariant": "^2.2.4",
@@ -7853,12 +7853,12 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/clx": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/clx/-/clx-1.0.0.tgz",
-      "integrity": "sha512-SkXPawXFlkeufjQgFaj88Qdtt4yRYxqKy+N+XM/01Vqn98qzMIgwmd9RUOOv83qNUf9poZ3u5y5/rRJIHaN+gw==",
-      "dependencies": {
-        "express": "^4.13.4"
+    "node_modules/clsx": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.0.tgz",
+      "integrity": "sha512-m3iNNWpd9rl3jvvcBnu70ylMdrXt8Vlq4HYadnU5fwcOtvkSQWPmj7amUcDT2qYI7risszBjI5AUIUox9D16pg==",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/color-convert": {

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "@remix-run/express": "^2.8.0",
     "@remix-run/node": "^2.8.0",
     "@remix-run/react": "^2.8.0",
-    "clx": "^1.0.0",
+    "clsx": "^2.1.0",
     "compression": "^1.7.4",
     "express": "^4.18.2",
     "invariant": "^2.2.4",


### PR DESCRIPTION
## Description

When setting up the repo, I mistyped `clsx` and installed `clx` instead 

## Solution
- Remove `clx`
- Install `cslx`